### PR TITLE
fix: discard changes when the modal is closed

### DIFF
--- a/src/components/context/EditItemModalContext.js
+++ b/src/components/context/EditItemModalContext.js
@@ -43,6 +43,7 @@ const EditItemModalProvider = ({ children }) => {
   const onClose = () => {
     setOpen(false);
     setItem(null);
+    setUpdatedItem(null);
   };
 
   const submit = () => {


### PR DESCRIPTION
This PR fixes the edition of items.

The editor no longer shows the previous edited value.

closes #191 