### PR TITLE
264/cookies banner

### DIFF
--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -77,6 +77,7 @@ import './commands/navigation';
 import { CURRENT_USER, MEMBERS } from '../fixtures/members';
 import { SAMPLE_FLAGS } from '../fixtures/flags';
 import { APPS_LIST } from '../fixtures/apps/apps';
+import { ACCEPT_COOKIES_NAME } from '../../src/config/constants';
 import {
   SAMPLE_CATEGORIES,
   SAMPLE_CATEGORY_TYPES,
@@ -133,6 +134,9 @@ Cypress.Commands.add(
     const allItems = [...cachedItems, ...recycledItems];
 
     cy.setCookie('session', currentMember ? 'somecookie' : null);
+
+    // hide cookie banner by default
+    cy.setCookie(ACCEPT_COOKIES_NAME, true);
 
     mockGetAppListRoute(APPS_LIST);
 
@@ -246,7 +250,7 @@ Cypress.Commands.add(
     mockPostAvatar(postAvatarError);
 
     mockImportZip(importZipError);
-    
+
     mockGetCategoryTypes(categoryTypes);
 
     mockGetCategories(categories, getCategoriesError);

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -136,7 +136,7 @@ Cypress.Commands.add(
     cy.setCookie('session', currentMember ? 'somecookie' : null);
 
     // hide cookie banner by default
-    cy.setCookie(ACCEPT_COOKIES_NAME, true);
+    cy.setCookie(ACCEPT_COOKIES_NAME, 'true');
 
     mockGetAppListRoute(APPS_LIST);
 

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "http-status-codes": "2.2.0",
     "i18next": "21.6.5",
     "immutable": "4.0.0",
+    "js-cookie": "3.0.1",
     "katex": "0.15.1",
     "lodash.truncate": "4.4.2",
     "prop-types": "15.8.1",

--- a/src/components/common/CookiesBanner.js
+++ b/src/components/common/CookiesBanner.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import { CookiesBanner } from '@graasp/ui';
+import { useTranslation } from 'react-i18next';
+import { ACCEPT_COOKIES_NAME } from '../../config/constants';
+
+const Component = () => {
+  const { t } = useTranslation();
+
+  return (
+    <CookiesBanner
+      acceptText={t('Accept all')}
+      declineButtonText={t('Reject non-essential')}
+      cookieName={ACCEPT_COOKIES_NAME}
+      text={t(
+        `We use cookies and other tracking technologies to improve your browsing experience on our website, to analyze our website traffic, and to understand where our visitors are coming from. By browsing our website, you consent to our use of cookies and other tracking technologies.`,
+      )}
+    />
+  );
+};
+
+export default Component;

--- a/src/components/main/Main.js
+++ b/src/components/main/Main.js
@@ -8,6 +8,7 @@ import { HEADER_HEIGHT, LEFT_MENU_WIDTH } from '../../config/constants';
 import MainMenu from './MainMenu';
 import Header from '../layout/Header';
 import { LayoutContext } from '../context/LayoutContext';
+import CookiesBanner from '../common/CookiesBanner';
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -67,6 +68,7 @@ const Main = ({ children }) => {
   return (
     <div className={classes.root}>
       <CssBaseline />
+      <CookiesBanner />
       <Header toggleMenu={toggleDrawer} isMenuOpen={isMainMenuOpen} />
       <Drawer
         className={classes.drawer}

--- a/src/config/constants.js
+++ b/src/config/constants.js
@@ -181,3 +181,6 @@ export const CATEGORY_TYPES = {
   LEVEL: 'level',
   DISCIPLINE: 'discipline',
 };
+
+// todo: factor out in graasp constants/utils
+export const ACCEPT_COOKIES_NAME = 'accept-all-cookies';

--- a/src/index.js
+++ b/src/index.js
@@ -7,8 +7,9 @@ import * as serviceWorker from './serviceWorker';
 
 import '@graasp/ui/dist/bundle.css';
 import { GA_MEASUREMENT_ID } from './config/constants';
+import { hasAcceptedCookies } from './utils/cookies';
 
-if (GA_MEASUREMENT_ID) {
+if (GA_MEASUREMENT_ID && hasAcceptedCookies()) {
   ReactGA.initialize(GA_MEASUREMENT_ID);
   ReactGA.send('pageview');
 }

--- a/src/langs/en.json
+++ b/src/langs/en.json
@@ -157,6 +157,9 @@
     "Level": "Level",
     "Please choose from the list": "Please choose from the list",
     "Hide Item": "Hide Item",
-    "Show Item": "Show Item"
+    "Show Item": "Show Item",
+    "We use cookies and other tracking technologies to improve your browsing experience on our website, to analyze our website traffic, and to understand where our visitors are coming from. By browsing our website, you consent to our use of cookies and other tracking technologies.": "We use cookies and other tracking technologies to improve your browsing experience on our website, to analyze our website traffic, and to understand where our visitors are coming from. By browsing our website, you consent to our use of cookies and other tracking technologies.",
+    "Accept all": "Accept all",
+    "Reject non-essential": "Reject non-essential"
   }
 }

--- a/src/langs/fr.json
+++ b/src/langs/fr.json
@@ -152,6 +152,9 @@
     "Category": "Catégorie",
     "Write the folder decription here...": "Ecrire la description du dossier ici...",
     "Hide Item": "Cacher l'élément",
-    "Show Item": "Montrer l'élément"
+    "Show Item": "Montrer l'élément",
+    "We use cookies and other tracking technologies to improve your browsing experience on our website, to analyze our website traffic, and to understand where our visitors are coming from. By browsing our website, you consent to our use of cookies and other tracking technologies.": "Nous utilisons des cookies et d'autres technologies de traçage pour améliorer votre expérience de navigation sur notre site, pour analyser le traffic et d'où viennent nos visiteurs. En naviguant sur notre site web, vous acceptez l'utilisation des cookies et d'autres technologies de traçage.",
+    "Accept all": "Tout accepter",
+    "Reject non-essential": "Refuser les cookies optionnels"
   }
 }

--- a/src/utils/cookies.js
+++ b/src/utils/cookies.js
@@ -1,0 +1,6 @@
+import Cookies from 'js-cookie';
+import { ACCEPT_COOKIES_NAME } from '../config/constants';
+
+// eslint-disable-next-line import/prefer-default-export
+export const hasAcceptedCookies = () =>
+  Cookies.get(ACCEPT_COOKIES_NAME) === 'true';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1899,13 +1899,14 @@ __metadata:
 
 "@graasp/ui@github:graasp/graasp-ui.git":
   version: 0.2.0
-  resolution: "@graasp/ui@https://github.com/graasp/graasp-ui.git#commit=5c1abc2cccbdbde10461d75e8bb7454a9140c64d"
+  resolution: "@graasp/ui@https://github.com/graasp/graasp-ui.git#commit=976688dc753fa11a0c6d84f7ff20072a6a00cf8b"
   dependencies:
     "@graasp/utils": "github:graasp/graasp-utils.git#1/init"
     clsx: 1.1.1
     http-status-codes: 2.2.0
     immutable: 4.0.0
     katex: 0.15.1
+    react-cookie-consent: 7.2.1
     react-i18next: 11.15.3
     react-quill: 1.3.5
     react-text-mask: 5.4.3
@@ -1917,7 +1918,7 @@ __metadata:
     i18next: 21.3.1
     react: ^16.13.1
     react-dom: 16.13.1
-  checksum: 7cb8740b3dc72cd5b01ae78b584326182486e7776f64a917981cbb44ea67ee358db027e8b56b48390f02a688285c94cd9aadd5be1559eac8ec1cd239e33fb1e3
+  checksum: d0e0491b2fb2b2633660ba44516c14dd23732a77d569588397102463361dec567af241de3c11dfa4d3ff789fdaf5134abcb6c903ed4681c4676d48c31315aadc
   languageName: node
   linkType: hard
 
@@ -9797,6 +9798,7 @@ __metadata:
     i18next: 21.6.5
     immutable: 4.0.0
     istanbul-lib-coverage: 3.2.0
+    js-cookie: 3.0.1
     katex: 0.15.1
     lodash.truncate: 4.4.2
     npm-run-all: 4.1.5
@@ -11928,6 +11930,13 @@ __metadata:
   version: 3.0.1
   resolution: "js-cookie@npm:3.0.1"
   checksum: bb48de67e2a6bd1ae3dfd6b2d5a167c33dd0c5a37e909206161eb0358c98f17cb55acd55827a58e9eea3630d89444e7479f7938ef4420dda443218b8c434a4c3
+  languageName: node
+  linkType: hard
+
+"js-cookie@npm:^2.2.1":
+  version: 2.2.1
+  resolution: "js-cookie@npm:2.2.1"
+  checksum: 9b1fb980a1c5e624fd4b28ea4867bb30c71e04c4484bb3a42766344c533faa684de9498e443425479ec68609e96e27b60614bfe354877c449c631529b6d932f2
   languageName: node
   linkType: hard
 
@@ -15995,6 +16004,18 @@ __metadata:
     react: ^16.8.5 || ^17.0.0
     react-dom: ^16.8.5 || ^17.0.0
   checksum: 12b7e9fbe872783e0f899e03f2e80deee085aa1e2cec3d556c1d06bdbafbda7a3c9cf7a3a6b26544617eb2e50d0e3518001bd8300370704bf5a8c9c21f54ec90
+  languageName: node
+  linkType: hard
+
+"react-cookie-consent@npm:7.2.1":
+  version: 7.2.1
+  resolution: "react-cookie-consent@npm:7.2.1"
+  dependencies:
+    js-cookie: ^2.2.1
+    prop-types: ^15.7.2
+  peerDependencies:
+    react: ^16.13.1 || ^17.0.0
+  checksum: 9676e9611998f58e43ae76721f33b80eb95be37ad3937de0fd4f623ac5e7c72573d45cc36ca5e0c6b9d494a09a8aea1aea7ba8ae5ad0ebb2b692837ef78a561e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR adds the cookies banner. I've followed Reddit banner which gives both options: Reject non-essential and Accept all. This allows us to always use our session cookie.

(the logo over the banner only exists in dev environment) The text is the same as on desktop content website.

If you agree on the component, I'll edit this PR and export it in graasp-ui to reuse it for our other platforms.

<img width="1060" alt="Screenshot 2022-01-14 at 17 28 48" src="https://user-images.githubusercontent.com/11229627/149554165-b2a4a5c1-15c3-43a3-994a-1dd3a547f468.png">
 
close #264 