### PR TITLE
fix: change header button size to `medium` for consistency

### DIFF
--- a/src/components/common/PlayerViewButton.js
+++ b/src/components/common/PlayerViewButton.js
@@ -28,7 +28,7 @@ const PlayerViewButton = ({ itemId }) => {
         onClick={onClick}
         id={buildPlayerButtonId(itemId)}
       >
-        <PlayCircleFilledIcon fontSize="small" />
+        <PlayCircleFilledIcon />
       </IconButton>
     </Tooltip>
   );

--- a/src/components/common/ShareButton.js
+++ b/src/components/common/ShareButton.js
@@ -27,7 +27,7 @@ const ShareButton = ({ itemId }) => {
         onClick={onClick}
         id={buildShareButtonId(itemId)}
       >
-        {isItemSharingOpen ? <CloseIcon /> : <ShareIcon fontSize="small" />}
+        {isItemSharingOpen ? <CloseIcon /> : <ShareIcon />}
       </IconButton>
     </Tooltip>
   );

--- a/src/components/item/header/ItemHeaderActions.js
+++ b/src/components/item/header/ItemHeaderActions.js
@@ -82,7 +82,7 @@ const ItemHeaderActions = ({ onClickMetadata, onClickChatbox, item }) => {
                 }}
                 id={buildEditButtonId(id)}
               >
-                <EditIcon fontSize="small" />
+                <EditIcon />
               </IconButton>
             </Tooltip>
           )}


### PR DESCRIPTION
This PR changes the header button size to `medium` to make them consistant with the other buttons.

closes #308 