### PR TITLE
Fix item name Field and App name Field

### DIFF
--- a/cypress/fixtures/apps.js
+++ b/cypress/fixtures/apps.js
@@ -29,7 +29,7 @@ export const GRAASP_APP_PARENT_FOLDER = {
   path: 'bdf09f5a_5688_11eb_ae93_0242ac130002',
   extra: {
     image: 'someimageurl',
-    name: APP_NAME
+    name: APP_NAME,
   },
 };
 
@@ -43,7 +43,7 @@ export const GRAASP_APP_CHILDREN_ITEM = {
   extra: {
     [ITEM_TYPES.APP]: { 
       url: 'http://localhost.com:3333',
-      name: APP_NAME 
+      name: APP_NAME,
     },
   },
   creator: CURRENT_USER.id,
@@ -58,7 +58,7 @@ export const APP_USING_CONTEXT_ITEM = {
   extra: {
     [ITEM_TYPES.APP]: {
       url: `${API_HOST}/${buildAppItemLinkForTest('app.html')}`,
-      name: APP_NAME
+      name: APP_NAME,
     },
   },
   creator: CURRENT_USER.id,

--- a/cypress/fixtures/apps/apps.js
+++ b/cypress/fixtures/apps/apps.js
@@ -1,4 +1,5 @@
-export const APP_NAME = "test app";
+export const APP_NAME = 'test app';
+export const NEW_APP_NAME = 'my new test app';
 
 export const APPS_LIST = [
     {

--- a/cypress/integration/item/edit/editFolder.spec.js
+++ b/cypress/integration/item/edit/editFolder.spec.js
@@ -2,8 +2,9 @@ import { DEFAULT_ITEM_LAYOUT_MODE } from '../../../../src/config/constants';
 import { ITEM_LAYOUT_MODES } from '../../../../src/enums';
 import { buildItemPath, HOME_PATH } from '../../../../src/config/paths';
 import { EDITED_FIELDS, SAMPLE_ITEMS } from '../../../fixtures/items';
-import { EDIT_ITEM_PAUSE } from '../../../support/constants';
+import { EDIT_ITEM_PAUSE, TABLE_ITEM_RENDER_TIME } from '../../../support/constants';
 import { editItem, editCaptionFromViewPage } from './utils';
+import { buildEditButtonId, ITEM_FORM_CONFIRM_BUTTON_ID } from "../../../../src/config/selectors";
 
 describe('Edit Folder', () => {
   describe('List', () => {
@@ -25,6 +26,30 @@ describe('Edit Folder', () => {
           // caption content might be wrapped with html tags
           expect(body?.description).to.contain(caption);
         });
+      });
+    });
+
+    describe('Dumb user', () => {
+      it('confirm with empty name', () => {
+        cy.setUpApi(SAMPLE_ITEMS);
+        cy.visit(HOME_PATH);
+
+        // wait for the render
+        cy.wait(TABLE_ITEM_RENDER_TIME);
+
+        // click edit button
+        const itemId = SAMPLE_ITEMS.items[0].id;
+        cy.get(`#${buildEditButtonId(itemId)}`).click();
+
+        cy.fillFolderModal({
+          // put an empty name for the folder
+            name: '',
+          },
+          { confirm: false }
+        );
+
+        // check that the button can not be clicked
+        cy.get(`#${ITEM_FORM_CONFIRM_BUTTON_ID}`).should('be.disabled');
       });
     });
 
@@ -50,10 +75,10 @@ describe('Edit Folder', () => {
 
       cy.wait('@editItem').then(
         ({
-          response: {
-            body: { id, name, description },
-          },
-        }) => {
+           response: {
+             body: { id, name, description },
+           },
+         }) => {
           // check item is edited and updated
           expect(id).to.equal(itemToEdit.id);
           expect(name).to.equal(EDITED_FIELDS.name);
@@ -86,10 +111,10 @@ describe('Edit Folder', () => {
 
       cy.wait('@editItem').then(
         ({
-          response: {
-            body: { id, name },
-          },
-        }) => {
+           response: {
+             body: { id, name },
+           },
+         }) => {
           // check item is edited and updated
           cy.wait(EDIT_ITEM_PAUSE);
           expect(id).to.equal(itemToEdit.id);
@@ -142,10 +167,10 @@ describe('Edit Folder', () => {
 
       cy.wait('@editItem').then(
         ({
-          response: {
-            body: { id, name },
-          },
-        }) => {
+           response: {
+             body: { id, name },
+           },
+         }) => {
           // check item is edited and updated
           cy.wait(EDIT_ITEM_PAUSE);
           cy.get('@getOwnItems');
@@ -174,10 +199,10 @@ describe('Edit Folder', () => {
 
       cy.wait('@editItem').then(
         ({
-          response: {
-            body: { id, name },
-          },
-        }) => {
+           response: {
+             body: { id, name },
+           },
+         }) => {
           // check item is edited and updated
           cy.wait(EDIT_ITEM_PAUSE);
           expect(id).to.equal(itemToEdit.id);

--- a/cypress/integration/item/edit/editFolder.spec.js
+++ b/cypress/integration/item/edit/editFolder.spec.js
@@ -2,9 +2,15 @@ import { DEFAULT_ITEM_LAYOUT_MODE } from '../../../../src/config/constants';
 import { ITEM_LAYOUT_MODES } from '../../../../src/enums';
 import { buildItemPath, HOME_PATH } from '../../../../src/config/paths';
 import { EDITED_FIELDS, SAMPLE_ITEMS } from '../../../fixtures/items';
-import { EDIT_ITEM_PAUSE, TABLE_ITEM_RENDER_TIME } from '../../../support/constants';
+import {
+  EDIT_ITEM_PAUSE,
+  TABLE_ITEM_RENDER_TIME,
+} from '../../../support/constants';
 import { editItem, editCaptionFromViewPage } from './utils';
-import { buildEditButtonId, ITEM_FORM_CONFIRM_BUTTON_ID } from "../../../../src/config/selectors";
+import {
+  buildEditButtonId,
+  ITEM_FORM_CONFIRM_BUTTON_ID,
+} from '../../../../src/config/selectors';
 
 describe('Edit Folder', () => {
   describe('List', () => {
@@ -29,28 +35,27 @@ describe('Edit Folder', () => {
       });
     });
 
-    describe('Dumb user', () => {
-      it('confirm with empty name', () => {
-        cy.setUpApi(SAMPLE_ITEMS);
-        cy.visit(HOME_PATH);
+    it('confirm with empty name', () => {
+      cy.setUpApi(SAMPLE_ITEMS);
+      cy.visit(HOME_PATH);
 
-        // wait for the render
-        cy.wait(TABLE_ITEM_RENDER_TIME);
+      // wait for the render
+      cy.wait(TABLE_ITEM_RENDER_TIME);
 
-        // click edit button
-        const itemId = SAMPLE_ITEMS.items[0].id;
-        cy.get(`#${buildEditButtonId(itemId)}`).click();
+      // click edit button
+      const itemId = SAMPLE_ITEMS.items[0].id;
+      cy.get(`#${buildEditButtonId(itemId)}`).click();
 
-        cy.fillFolderModal({
+      cy.fillFolderModal(
+        {
           // put an empty name for the folder
-            name: '',
-          },
-          { confirm: false }
-        );
+          name: '',
+        },
+        { confirm: false },
+      );
 
-        // check that the button can not be clicked
-        cy.get(`#${ITEM_FORM_CONFIRM_BUTTON_ID}`).should('be.disabled');
-      });
+      // check that the button can not be clicked
+      cy.get(`#${ITEM_FORM_CONFIRM_BUTTON_ID}`).should('be.disabled');
     });
 
     it('edit folder on Home', () => {

--- a/cypress/integration/item/publish/publishedItem.spec.js
+++ b/cypress/integration/item/publish/publishedItem.spec.js
@@ -50,15 +50,18 @@ describe('Published Item', () => {
   });
   it('Show published state on button', () => {
     // click validate item button
-    cy.get(`#${ITEM_PUBLISH_BUTTON_ID} > span`).children().children().should('exist');
-  });  
+    cy.get(`#${ITEM_PUBLISH_BUTTON_ID} > span`)
+      .children()
+      .children()
+      .should('exist');
+  });
   it('Unpublish item', () => {
     cy.get(`#${ITEM_UNPUBLISH_BUTTON_ID}`).click();
     cy.wait('@deleteItemTag').then(({ request: { url } }) => {
       // should contain published tag id
       expect(url).to.contain(item.tags[1].id);
     });
-  })
+  });
 });
 
 describe('Validated Item', () => {

--- a/cypress/support/commands/item.js
+++ b/cypress/support/commands/item.js
@@ -23,6 +23,7 @@ import {
 } from '../../../src/utils/itemExtra';
 import { getParentsIdsFromPath } from '../../../src/utils/item';
 import { TREE_VIEW_PAUSE } from '../constants';
+import { NEW_APP_NAME } from '../../fixtures/apps/apps';
 
 Cypress.Commands.add('fillShareForm', ({ member, permission }) => {
   // select permission
@@ -83,7 +84,9 @@ Cypress.Commands.add(
   ({ name = '', description = '' }, { confirm = true } = {}) => {
     cy.fillBaseItemModal({ name }, { confirm: false });
     // first select all the text and then remove it to have a clear field, then type new description
-    cy.get(`#${FOLDER_FORM_DESCRIPTION_ID}`).type(`{selectall}{backspace}${description}`);
+    cy.get(`#${FOLDER_FORM_DESCRIPTION_ID}`).type(
+      `{selectall}{backspace}${description}`,
+    );
 
     if (confirm) {
       cy.get(`#${ITEM_FORM_CONFIRM_BUTTON_ID}`).click();
@@ -127,7 +130,6 @@ Cypress.Commands.add(
     cy.fillBaseItemModal({ name }, { confirm: false });
 
     cy.get(`#${ITEM_FORM_APP_URL_ID}`).click();
-    // todo: can not edit name field in modal
     if (type) {
       cy.get(`#${ITEM_FORM_APP_URL_ID}`).type(getAppExtra(extra)?.url);
     } else {
@@ -137,6 +139,10 @@ Cypress.Commands.add(
         'have.value',
         getAppExtra(extra)?.name,
       );
+      // edit the app name
+      cy.get(`#${ITEM_FORM_NAME_INPUT_ID}`)
+        .type(`{selectall}{backspace}${NEW_APP_NAME}`)
+        .should('have.value', NEW_APP_NAME);
     }
 
     if (confirm) {

--- a/cypress/support/commands/item.js
+++ b/cypress/support/commands/item.js
@@ -69,7 +69,8 @@ Cypress.Commands.add('fillTreeModal', (toItemPath) => {
 Cypress.Commands.add(
   'fillBaseItemModal',
   ({ name = '' }, { confirm = true } = {}) => {
-    cy.get(`#${ITEM_FORM_NAME_INPUT_ID}`).type(`{selectall}${name}`);
+    // first select all the text and then remove it to have a clear field, then type new text
+    cy.get(`#${ITEM_FORM_NAME_INPUT_ID}`).type(`{selectall}{backspace}${name}`);
 
     if (confirm) {
       cy.get(`#${ITEM_FORM_CONFIRM_BUTTON_ID}`).click();
@@ -81,8 +82,8 @@ Cypress.Commands.add(
   'fillFolderModal',
   ({ name = '', description = '' }, { confirm = true } = {}) => {
     cy.fillBaseItemModal({ name }, { confirm: false });
-
-    cy.get(`#${FOLDER_FORM_DESCRIPTION_ID}`).type(`{selectall}${description}`);
+    // first select all the text and then remove it to have a clear field, then type new description
+    cy.get(`#${FOLDER_FORM_DESCRIPTION_ID}`).type(`{selectall}{backspace}${description}`);
 
     if (confirm) {
       cy.get(`#${ITEM_FORM_CONFIRM_BUTTON_ID}`).click();
@@ -94,7 +95,8 @@ Cypress.Commands.add(
   'fillLinkModal',
   ({ extra = {} }, { confirm = true } = {}) => {
     cy.get(`#${ITEM_FORM_LINK_INPUT_ID}`).type(
-      `{selectall}${getEmbeddedLinkExtra(extra)?.url}`,
+      // first select all the text and then remove it to have a clear field, then type new text
+      `{selectall}{backspace}${getEmbeddedLinkExtra(extra)?.url}`,
     );
 
     if (confirm) {
@@ -109,7 +111,8 @@ Cypress.Commands.add(
     cy.fillBaseItemModal({ name }, { confirm: false });
 
     cy.get(ITEM_FORM_DOCUMENT_TEXT_SELECTOR).type(
-      `{selectall}${getDocumentExtra(extra)?.content}`,
+      // first select all the text and then remove it to have a clear field, then type new text
+      `{selectall}{backspace}${getDocumentExtra(extra)?.content}`,
     );
 
     if (confirm) {
@@ -124,7 +127,7 @@ Cypress.Commands.add(
     cy.fillBaseItemModal({ name }, { confirm: false });
 
     cy.get(`#${ITEM_FORM_APP_URL_ID}`).click();
-
+    // todo: can not edit name field in modal
     if (type) {
       cy.get(`#${ITEM_FORM_APP_URL_ID}`).type(getAppExtra(extra)?.url);
     } else {

--- a/src/components/common/HideButton.js
+++ b/src/components/common/HideButton.js
@@ -16,13 +16,12 @@ const HideButton = ({ item }) => {
   const { data: tags } = hooks.useItemTags(item.id);
   const addTag = useMutation(MUTATION_KEYS.POST_ITEM_TAG);
   const removeTag = useMutation(MUTATION_KEYS.DELETE_ITEM_TAG);
-
   const hiddenTag = tags
     ?.filter(({ tagId }) => tagId === HIDDEN_ITEM_TAG_ID)
     ?.first();
-
   // since children items are hidden because parent is hidden, the hidden tag should be removed from the root item
-  const isOriginalHiddenItem = hiddenTag?.itemPath === item.path;
+  // if hiddenTag is undefined -> the item is not hidden
+  const isOriginalHiddenItem = !hiddenTag || hiddenTag?.itemPath === item.path;
 
   const handlePin = () => {
     if (hiddenTag) {

--- a/src/components/common/HideButton.js
+++ b/src/components/common/HideButton.js
@@ -45,18 +45,20 @@ const HideButton = ({ item }) => {
 
   return (
     <Tooltip title={tooltip}>
-      <IconButton
-        aria-label={tooltip}
-        className={HIDDEN_ITEM_BUTTON_CLASS}
-        onClick={handlePin}
-        disable={!isOriginalHiddenItem}
-      >
-        {hiddenTag ? (
-          <VisibilityOff fontSize="small" />
-        ) : (
-          <Visibility fontSize="small" />
-        )}
-      </IconButton>
+      <span>
+        <IconButton
+          aria-label={tooltip}
+          className={HIDDEN_ITEM_BUTTON_CLASS}
+          onClick={handlePin}
+          disabled={!isOriginalHiddenItem}
+        >
+          {hiddenTag ? (
+            <VisibilityOff fontSize="small" />
+          ) : (
+            <Visibility fontSize="small" />
+          )}
+        </IconButton>
+      </span>
     </Tooltip>
   );
 };

--- a/src/components/common/PublishButton.js
+++ b/src/components/common/PublishButton.js
@@ -27,7 +27,7 @@ const PublishButton = ({ itemId }) => {
         onClick={onClick}
         id={buildPublishButtonId(itemId)}
       >
-        {isItemPublishOpen ? <CloseIcon /> : <ExploreIcon fontSize="small" />}
+        {isItemPublishOpen ? <CloseIcon /> : <ExploreIcon />}
       </IconButton>
     </Tooltip>
   );

--- a/src/components/context/EditItemModalContext.js
+++ b/src/components/context/EditItemModalContext.js
@@ -15,9 +15,7 @@ import { ITEM_TYPES } from '../../enums';
 import BaseItemForm from '../item/form/BaseItemForm';
 import DocumentForm from '../item/form/DocumentForm';
 import { isItemValid } from '../../utils/item';
-
-// time to be considered between 2 clicks for a double-click (https://en.wikipedia.org/wiki/Double-click#Speed_and_timing)
-const DOUBLE_CLICK_DELAY_MS = 500;
+import { DOUBLE_CLICK_DELAY_MS } from '../../config/constants';
 
 const EditItemModalContext = React.createContext();
 
@@ -51,6 +49,7 @@ const EditItemModalProvider = ({ children }) => {
     setItem(null);
     setUpdatedItem(null);
     // schedule button disable state reset AFTER end of click event handling
+    // todo: factor out this logic to graasp-ui
     setTimeout(() => setConfirmButtonDisabled(false), DOUBLE_CLICK_DELAY_MS);
   };
 

--- a/src/components/context/EditItemModalContext.js
+++ b/src/components/context/EditItemModalContext.js
@@ -97,7 +97,11 @@ const EditItemModalProvider = ({ children }) => {
         <Button onClick={onClose} variant="text">
           {t('Cancel')}
         </Button>
-        <Button onClick={submit} id={ITEM_FORM_CONFIRM_BUTTON_ID}>
+        <Button
+          // should not allow users to save if the name is empty
+          onClick={submit}
+          id={ITEM_FORM_CONFIRM_BUTTON_ID}
+        >
           {t('Save')}
         </Button>
       </DialogActions>

--- a/src/components/context/EditItemModalContext.js
+++ b/src/components/context/EditItemModalContext.js
@@ -8,6 +8,7 @@ import DialogTitle from '@material-ui/core/DialogTitle';
 import { makeStyles } from '@material-ui/core';
 import PropTypes from 'prop-types';
 import { MUTATION_KEYS } from '@graasp/query-client';
+import { toast } from 'react-toastify';
 import { useMutation } from '../../config/queryClient';
 import FolderForm from '../item/form/FolderForm';
 import { ITEM_FORM_CONFIRM_BUTTON_ID } from '../../config/selectors';
@@ -58,7 +59,7 @@ const EditItemModalProvider = ({ children }) => {
       return;
     }
     if (!isItemValid({ ...item, ...updatedProperties })) {
-      // todo: notify user
+      toast.error(t('Item is invalid'));
       return;
     }
 

--- a/src/components/item/form/AppForm.js
+++ b/src/components/item/form/AppForm.js
@@ -21,7 +21,7 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-const AppForm = ({ onChange, item }) => {
+const AppForm = ({ onChange, item, updatedProperties }) => {
   const { t } = useTranslation();
   const [newName, setNewName] = useState(item?.name);
 
@@ -45,7 +45,11 @@ const AppForm = ({ onChange, item }) => {
   return (
     <div>
       <Typography variant="h6">{t('Create an App')}</Typography>
-      <BaseItemForm onChange={onChange} item={{ ...item, name: newName }} />
+      <BaseItemForm
+        onChange={onChange}
+        item={{ ...item, name: newName }}
+        updatedProperties={updatedProperties}
+      />
 
       {isAppsLoading ? (
         <Skeleton height={60} />
@@ -96,10 +100,19 @@ AppForm.propTypes = {
       image: PropTypes.string,
     }),
   }),
+  updatedProperties: PropTypes.shape({
+    name: PropTypes.string,
+    extra: PropTypes.shape({
+      app: PropTypes.shape({
+        url: PropTypes.string,
+      }),
+    }),
+  }),
 };
 
 AppForm.defaultProps = {
   item: {},
+  updatedProperties: {},
 };
 
 export default AppForm;

--- a/src/components/item/form/BaseItemForm.js
+++ b/src/components/item/form/BaseItemForm.js
@@ -25,7 +25,6 @@ const BaseForm = ({ onChange, item, updatedProperties }) => {
       margin="dense"
       id={ITEM_FORM_NAME_INPUT_ID}
       label={t('Name')}
-      // can not clear name completely
       value={updatedProperties?.name ?? item?.name}
       onChange={handleNameInput}
       className={classes.shortInputField}

--- a/src/components/item/form/BaseItemForm.js
+++ b/src/components/item/form/BaseItemForm.js
@@ -25,7 +25,8 @@ const BaseForm = ({ onChange, item, updatedProperties }) => {
       margin="dense"
       id={ITEM_FORM_NAME_INPUT_ID}
       label={t('Name')}
-      value={updatedProperties?.name || item?.name}
+      // can not clear name completely
+      value={updatedProperties?.name ?? item?.name}
       onChange={handleNameInput}
       className={classes.shortInputField}
       // always shrink because setting name from defined app does not shrink automatically

--- a/src/components/main/NewItemModal.js
+++ b/src/components/main/NewItemModal.js
@@ -24,6 +24,7 @@ import DocumentForm from '../item/form/DocumentForm';
 import AppForm from '../item/form/AppForm';
 import ItemTypeTabs from './ItemTypeTabs';
 import ImportZip from './ImportZip';
+import { DOUBLE_CLICK_DELAY_MS } from '../../config/constants';
 
 const useStyles = makeStyles((theme) => ({
   dialogContent: {
@@ -38,9 +39,6 @@ const useStyles = makeStyles((theme) => ({
     width: '100%',
   },
 }));
-
-// time to be considered between 2 clicks for a double-click (https://en.wikipedia.org/wiki/Double-click#Speed_and_timing)
-const DOUBLE_CLICK_DELAY_MS = 500;
 
 const NewItemModal = ({ open, handleClose }) => {
   const { t } = useTranslation();

--- a/src/config/constants.js
+++ b/src/config/constants.js
@@ -66,6 +66,9 @@ export const DESCRIPTION_MAX_LENGTH = 30;
 export const DEFAULT_IMAGE_SRC =
   'https://pbs.twimg.com/profile_images/1300707321262346240/IsQAyu7q_400x400.jpg';
 
+// time to be considered between 2 clicks for a double-click (https://en.wikipedia.org/wiki/Double-click#Speed_and_timing)
+export const DOUBLE_CLICK_DELAY_MS = 500;
+
 export const ROOT_ID = 'root-id';
 
 export const TREE_VIEW_MAX_WIDTH = 400;


### PR DESCRIPTION
This PR fixes:
- Editing name of item field
- Editing App name field after selecting app in dropdown
- Publish icon size
- Missing span for Tooltip on hidden IconButton for HideButton

Tests now do a `{selectall}{backspace}some text` in the type instead of `{selectall}some text` so that the empty field can be tested too.

closes #332 
closes #330 